### PR TITLE
make basepath start with api

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2,24 +2,24 @@ openapi: 3.0.3
 info:
   title: TH1
   description: TH1
-  version: 1.4.0
+  version: 1.5.0
 
 servers:
-  - url: 'http://localhost:{port}/v1'
+  - url: 'http://localhost:{port}/api/v1'
     description: Local server
     variables: {
       port: {
         default: '8080'
       }
     }
-  - url: 'http://pg-doener-dev.virt.uni-oldenburg.de:{port}/v1'
+  - url: 'http://pg-doener-dev.virt.uni-oldenburg.de:{port}/api/v1'
     description: Dev server
     variables: {
       port: {
         default: '8080'
       }
     }
-  - url: 'http://pg-doener-prod.virt.uni-oldenburg.de:{port}/v1'
+  - url: 'http://pg-doener-prod.virt.uni-oldenburg.de:{port}/api/v1'
     description: Prod server
     variables: {
       port: {


### PR DESCRIPTION
This allows for better handling in the deployment. See also https://github.com/uol-esis/Frontend/pull/23#issue-2986616071 for more information on frontend deployment. By changing the `basePath` to start with `/api/` we can make the docker build more future proof by making the reverse proxy only forward paths starting with `api` to the backend. Otherwise we would have to look for every version (v1, v2, ...).